### PR TITLE
Allowing deploy from prime url

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,22 +59,23 @@ module.exports = {
                         const urlOrigins = deployPrimeUrl
                             ? [url, deployPrimeUrl]
                             : [url];
+                        const getArrayWithUniqueValues = arr => [...new Set(arr)];
                         const payload = {
-                            allowed_clients: client.allowed_clients.concat(urlOrigins),
-                            web_origins: client.web_origins.concat(urlOrigins),
-                            allowed_origins: client.allowed_origins.concat(urlOrigins),
-                            callbacks: client.callbacks.concat(
+                            allowed_clients: getArrayWithUniqueValues(client.allowed_clients.concat(urlOrigins)),
+                            web_origins: getArrayWithUniqueValues(client.web_origins.concat(urlOrigins)),
+                            allowed_origins: getArrayWithUniqueValues(client.allowed_origins.concat(urlOrigins)),
+                            callbacks: getArrayWithUniqueValues(client.callbacks.concat(
                                 [
                                     ...getComposeUrls('AUTH0_CALLBACK_PATHNAMES', url)
                                     ...getComposeUrls('AUTH0_CALLBACK_PATHNAMES', deployPrimeUrl)
                                 ]
-                            ),
-                            allowed_logout_urls: client.callbacks.concat(
+                            )),
+                            allowed_logout_urls: getArrayWithUniqueValues(client.callbacks.concat(
                                 [
                                     ...getComposeUrls('AUTH0_LOGOUT_PATHNAMES', url)
                                     ...getComposeUrls('AUTH0_LOGOUT_PATHNAMES', deployPrimeUrl)
                                 ]
-                            ),
+                            )),
                         };
                         management.clients.update(
                             { client_id: process.env.GATSBY_AUTH0_CLIENTID },


### PR DESCRIPTION
Allowing this urls too. When using github is needed to use deploy previews link that netlify provides to you.

`DEPLOY_PRIME_URL`: This URL represents the primary URL for an individual deploy, or a group of them, like branch deploys and Deploy Previews; for example, `https://feature-branch--petsof.netlify.app` or `https://deploy-preview-1--petsof.netlify.app`

[Docs](https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata)